### PR TITLE
Implements to launch Funding Detail via Deep link

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -25,7 +25,22 @@
             android:exported="false" />
         <activity
             android:name=".ui.detail.FundingDetailActivity"
-            android:exported="false" />
+            android:exported="true">
+
+            <intent-filter
+                android:autoVerify="true"
+                android:label="filterViewFundingDetail">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="www.favor-it.com"
+                    android:pathPrefix="/funding"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
         <activity
             android:name=".ui.login.LoginActivity"
             android:exported="false" />

--- a/androidApp/src/main/java/com/thinlineit/favorit_android/android/data/repository/FundingRepository.kt
+++ b/androidApp/src/main/java/com/thinlineit/favorit_android/android/data/repository/FundingRepository.kt
@@ -6,6 +6,6 @@ import com.thinlineit.favorit_android.android.ui.createfunding.CreateFundingResu
 
 interface FundingRepository {
     suspend fun create(request: CreateFundingRequest): Result<CreateFundingResult>
-    suspend fun getFunding(fundingId: Int): Funding
+    suspend fun getFunding(fundingId: Int): Result<Funding>
     suspend fun closeFunding(fundingId: Int): Result<Unit>
 }

--- a/androidApp/src/main/java/com/thinlineit/favorit_android/android/data/repository/FundingRepositoryImpl.kt
+++ b/androidApp/src/main/java/com/thinlineit/favorit_android/android/data/repository/FundingRepositoryImpl.kt
@@ -20,13 +20,13 @@ class FundingRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getFunding(fundingId: Int): Funding {
+    override suspend fun getFunding(fundingId: Int): Result<Funding> {
         val response = fundingApi.getFunding(fundingId)
         val body = response.body()
         return if (response.isSuccessful && body != null) {
-            body.data
+            Result.Success(body.data)
         } else {
-            throw Exception(response.message())
+            Result.Fail(Exception(response.message()))
         }
     }
 

--- a/androidApp/src/main/java/com/thinlineit/favorit_android/android/ui/detail/FundingDetailActivity.kt
+++ b/androidApp/src/main/java/com/thinlineit/favorit_android/android/ui/detail/FundingDetailActivity.kt
@@ -23,7 +23,29 @@ class FundingDetailActivity : AppCompatActivity() {
         ActivityFundingDetailBinding.inflate(layoutInflater)
     }
     val viewModel: FundingDetailViewModel by lazy {
-        ViewModelProvider(this)[FundingDetailViewModel::class.java]
+        ViewModelProvider(this)[FundingDetailViewModel::class.java].apply {
+            val fundingId =
+                parseFundingId(intent).takeIf { it != INVALID_FUNDING_ID } ?: return@apply
+            loadFundingDetail(fundingId)
+        }
+    }
+
+    private fun parseFundingId(intent: Intent): Int {
+        return if (intent.action == Intent.ACTION_VIEW) {
+            try {
+                intent.data?.lastPathSegment?.toInt() ?: INVALID_FUNDING_ID
+            } catch (e: Exception) {
+                INVALID_FUNDING_ID
+            }
+        } else {
+            intent.getIntExtra(FUNDING_ID, INVALID_FUNDING_ID)
+        }.takeIf {
+            it != INVALID_FUNDING_ID
+        } ?: this@FundingDetailActivity.run {
+            shortToast("Funding ID is invalid")
+            finish()
+            return INVALID_FUNDING_ID
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -110,5 +132,6 @@ class FundingDetailActivity : AppCompatActivity() {
         }
 
         const val FUNDING_ID = "FUNDING_ID"
+        const val INVALID_FUNDING_ID = -1
     }
 }

--- a/androidApp/src/main/java/com/thinlineit/favorit_android/android/ui/detail/FundingDetailActivity.kt
+++ b/androidApp/src/main/java/com/thinlineit/favorit_android/android/ui/detail/FundingDetailActivity.kt
@@ -60,6 +60,21 @@ class FundingDetailActivity : AppCompatActivity() {
     }
 
     private fun initObserver() {
+        viewModel.loadFundingResult.observe(this) {
+            when (it) {
+                is Result.Loading -> {
+                    // nothing to do
+                }
+                is Result.Fail -> {
+                    shortToast("Fail to load funding")
+                    finish()
+                }
+                is Result.Success -> {
+                    // nothing to do
+                }
+            }
+        }
+
         viewModel.closeFundingResult.observe(this) {
             when (it) {
                 is Result.Loading -> {

--- a/androidApp/src/main/java/com/thinlineit/favorit_android/android/ui/detail/FundingDetailViewModel.kt
+++ b/androidApp/src/main/java/com/thinlineit/favorit_android/android/ui/detail/FundingDetailViewModel.kt
@@ -3,7 +3,6 @@ package com.thinlineit.favorit_android.android.ui.detail
 import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,7 +10,6 @@ import com.thinlineit.favorit_android.android.R
 import com.thinlineit.favorit_android.android.data.Result
 import com.thinlineit.favorit_android.android.data.entity.Funding
 import com.thinlineit.favorit_android.android.data.entity.FundingState
-import com.thinlineit.favorit_android.android.ui.detail.FundingDetailActivity.Companion.FUNDING_ID
 import com.thinlineit.favorit_android.android.ui.detail.usecase.FundingDetailUseCase
 import com.thinlineit.favorit_android.android.util.NumberFormatter
 import com.thinlineit.favorit_android.android.util.toDate
@@ -22,10 +20,9 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class FundingDetailViewModel @Inject constructor(
     private val fundingDetailUseCase: FundingDetailUseCase,
-    state: SavedStateHandle
 ) : ViewModel() {
-    val fundingId: Int = state.get<Int>(FUNDING_ID) ?: throw Exception("Funding id is invalid")
-    val funding: MutableLiveData<Funding?> = MutableLiveData(null)
+    var fundingId: Int = 0
+
 
     val fundingDateProgressPercentage: LiveData<Int> = Transformations.map(funding) { funding ->
         if (funding == null) return@map 0

--- a/androidApp/src/main/java/com/thinlineit/favorit_android/android/ui/detail/usecase/GetFunding.kt
+++ b/androidApp/src/main/java/com/thinlineit/favorit_android/android/ui/detail/usecase/GetFunding.kt
@@ -1,8 +1,10 @@
 package com.thinlineit.favorit_android.android.ui.detail.usecase
 
+import com.thinlineit.favorit_android.android.data.Result
 import com.thinlineit.favorit_android.android.data.entity.Funding
 import com.thinlineit.favorit_android.android.data.repository.FundingRepository
 
 class GetFunding(private val fundingRepository: FundingRepository) {
-    suspend operator fun invoke(fundingId: Int): Funding = fundingRepository.getFunding(fundingId)
+    suspend operator fun invoke(fundingId: Int): Result<Funding> =
+        fundingRepository.getFunding(fundingId)
 }


### PR DESCRIPTION
## Description <!-- Please write what changes included in this PR -->
- [Add deep link intent filter](https://github.com/ThinLineIT/FavorIt_Android/commit/e5b4a8aab6e154e92bab180213fe617e2a3fc0a4)
- [Make FundingDetail works with Deep link](https://github.com/ThinLineIT/FavorIt_Android/commit/a4ce730c9df08eac76ef3748cd40bee46c70638a)
- [Change the loadFunding return type to Result<Funding>](https://github.com/ThinLineIT/FavorIt_Android/commit/095d9d609cb4df90a97ca254564031df939862ff)

**_Seems from Android12, Deep link doesn't work... we need to use AppLink as well_**

## Causes <!-- Please write what is the cause if it's bug fix PR -->
There is no way to access Funding Detail.
To access it, if user click the funding the link, then the funding detail is launched.
But it was not implemented.

## Test Case <!-- Please write what what did you test by yourself to check the feature is work correctly -->
- call `adb shell am start -W -a android.intent.action.VIEW -d "https://www.favor-it.me/funding/33"` on terminal

## Trello Card <!-- Please write the link of Trello card -->
